### PR TITLE
fix(parser): sends cc and bcc emails

### DIFF
--- a/config.js
+++ b/config.js
@@ -12,9 +12,9 @@ export const config = {
   // Be very careful to use only legitimate email address in the field bellow. Your server may blacklisted if you fail to do this.
   from: "example@example.com",
   // Add a list of email addresses to receive a copy of emails sent.
-  cc: ["nelson@ocastudios.com"],
+  cc: ["examplecc@example.com"],
   // Add a list of email addresses to receive a blind copy of emails sent.
-  bcc: ["nelsondovale@gmail.com"],
+  bcc: ["examplebcc@example.com"],
   // Configure your Simple Mail Transport Protocol - SMTP
   smtp: {
     host: "smtp.ethereal.email",

--- a/src/parser.js
+++ b/src/parser.js
@@ -59,13 +59,19 @@ function folder2message(message, subscription, cfg = config) {
     ? message.files.txt.content
     : plainTextVersion(html);
   const subject = plainTextVersion(message.subject);
-  return {
-    text: processVariables(text, subscription),
-    html: processVariables(html, subscription),
-    subject: processVariables(subject, subscription),
-    to: plainTextVersion(subscription.customer.email),
-    from: plainTextVersion(cfg.from),
-  };
+  const result = {}
+  result.text = processVariables(text, subscription);
+  result.html = processVariables(html, subscription);
+  result.subject = processVariables(subject, subscription);
+  result.to = plainTextVersion(subscription.customer.email);
+  result.from = plainTextVersion(cfg.from);
+  if (cfg.cc && cfg.cc.length) {
+    result.cc = cfg.cc.join(', ');
+  }
+  if (cfg.bcc && cfg.bcc.length) {
+    result.bcc = cfg.bcc.join(', ');
+  }
+  return result;
 }
 
 /**

--- a/test/mockApi.js
+++ b/test/mockApi.js
@@ -90,7 +90,6 @@ export class MockApi {
   }
 
   get() {
-    console.log("This are my subscriptions", this.subscriptions);
     switch (this.what) {
       case "fx:subscriptions":
         return Promise.resolve(


### PR DESCRIPTION
Both cc and bcc were being ignored from config.